### PR TITLE
This changes allow to disable the pll algorithm to change the timestamp of the message header

### DIFF
--- a/driver/src/sick_scansegment_xd/config.cpp
+++ b/driver/src/sick_scansegment_xd/config.cpp
@@ -203,6 +203,7 @@ sick_scansegment_xd::Config::Config()
     // Default is "0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0", i.e. laserscan messages for layer 5, (elevation -0.07 degree, max number of scan points)
     laserscan_layer_filter = { 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
+    use_pll_correction = false;
 }
 
 /*
@@ -238,6 +239,7 @@ void sick_scansegment_xd::Config::PrintHelp(void)
     ROS_INFO_STREAM("-imu_enable=0|1 : enable or disable IMU data, default: " << imu_enable);
     ROS_INFO_STREAM("-imu_udp_port=<port>: udp port for multiScan imu data, default: " << imu_udp_port);
     ROS_INFO_STREAM("-imu_latency_microsec=<micro_sec>: imu latency in microseconds, default: " << imu_latency_microsec);
+    ROS_INFO_STREAM("-use_pll_correction=0|1 : enable or disable use of the pll correction algorithm, default: " << use_pll_correction);
 }
 
 /*
@@ -449,6 +451,7 @@ bool sick_scansegment_xd::Config::Init(int argc, char** argv)
         sick_scansegment_xd::util::parseVector(cli_msgpack_validator_layer_filter, msgpack_validator_filter_settings.msgpack_validator_layer_filter);
     if (setOptionalArgument(cli_parameter_map, "laserscan_layer_filter", cli_laserscan_layer_filter))
         sick_scansegment_xd::util::parseVector(cli_laserscan_layer_filter, laserscan_layer_filter);
+    setOptionalArgument(cli_parameter_map, "use_pll_correction", use_pll_correction);
 
     PrintConfig();
 
@@ -517,5 +520,6 @@ void sick_scansegment_xd::Config::PrintConfig(void)
     ROS_INFO_STREAM("msgpack_validator_elevation_end:                   " << msgpack_validator_filter_settings.msgpack_validator_elevation_end << " [rad]");
     ROS_INFO_STREAM("msgpack_validator_valid_segments:                  " << sick_scansegment_xd::util::printVector(msgpack_validator_valid_segments));
     ROS_INFO_STREAM("msgpack_validator_layer_filter:                    " << sick_scansegment_xd::util::printVector(msgpack_validator_filter_settings.msgpack_validator_layer_filter));
+    ROS_INFO_STREAM("use_pll_correction:                    " << use_pll_correction);
 
 }

--- a/driver/src/sick_scansegment_xd/config.cpp
+++ b/driver/src/sick_scansegment_xd/config.cpp
@@ -203,7 +203,7 @@ sick_scansegment_xd::Config::Config()
     // Default is "0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0", i.e. laserscan messages for layer 5, (elevation -0.07 degree, max number of scan points)
     laserscan_layer_filter = { 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-    use_pll_correction = false;
+    use_pll_correction = true; // default True, Defines whether the pll correction should be applied to correct the header timestamp
 }
 
 /*

--- a/driver/src/sick_scansegment_xd/config.cpp
+++ b/driver/src/sick_scansegment_xd/config.cpp
@@ -335,6 +335,7 @@ bool sick_scansegment_xd::Config::Init(rosNodePtr _node)
     std::string str_laserscan_layer_filter = "0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0";
     ROS_DECL_GET_PARAMETER(node, "laserscan_layer_filter", str_laserscan_layer_filter);
     sick_scansegment_xd::util::parseVector(str_laserscan_layer_filter, laserscan_layer_filter);
+    ROS_DECL_GET_PARAMETER(node, "use_pll_correction", use_pll_correction);
 
     if (imu_enable && scandataformat != 2)
     {

--- a/driver/src/sick_scansegment_xd/ros_msgpack_publisher.cpp
+++ b/driver/src/sick_scansegment_xd/ros_msgpack_publisher.cpp
@@ -56,6 +56,7 @@
 #include <sick_scan/sick_generic_callback.h>
 #include "sick_scansegment_xd/compact_parser.h"
 #include "sick_scansegment_xd/ros_msgpack_publisher.h"
+#include "softwarePLL.h"
 #if defined ROSSIMU
 #include "sick_scan/pointcloud_utils.h"
 #endif
@@ -403,6 +404,15 @@ sick_scansegment_xd::RosMsgpackPublisher::RosMsgpackPublisher(const std::string&
 			m_custom_pointclouds_cfg.push_back(custom_pointcloud_cfg);
 		}
 	}
+
+    if (config.use_pll_correction)
+    {
+      SoftwarePLL::instance().enableCorrection();
+    }
+    else
+    {
+        SoftwarePLL::instance().disableCorrection();
+    }
 }
 
 /*

--- a/driver/src/softwarePLL.cpp
+++ b/driver/src/softwarePLL.cpp
@@ -115,6 +115,11 @@ int SoftwarePLL::findDiffInFifo(double diff, double tol)
   return (numFnd);
 }
 
+void SoftwarePLL::disableCorrection()
+{
+  correctionDisabled = false;
+}
+
 /*!
 \brief Updates PLL internale State should be called only with network send timestamps
 
@@ -184,14 +189,23 @@ bool SoftwarePLL::updatePLL(uint32_t sec, uint32_t nanoSec, uint32_t curtick)
 //TODO Kommentare
 bool SoftwarePLL::getCorrectedTimeStamp(uint32_t &sec, uint32_t &nanoSec, uint32_t curtick)
 {
-  if (IsInitialized() == false)
+  if ((IsInitialized() == false) && (correctionDisabled == false))
   {
     return (false);
   }
 
-  double relTimeStamp = extraPolateRelativeTimeStamp(curtick); // evtl. hier wg. Ueberlauf noch einmal pruefen
-  double corrTime = relTimeStamp + this->FirstTimeStamp();
-  sec = (uint32_t) corrTime;
+  double corrTime;
+  if (correctionDisabled)
+  {
+    double relTimeStamp = extraPolateRelativeTimeStamp(curtick); // evtl. hier wg. Ueberlauf noch einmal pruefen
+    corrTime = relTimeStamp + this->FirstTimeStamp();
+  }
+  else
+  {
+    corrTime = static_cast<double>(curtick);
+  }
+
+  sec = static_cast<uint32_t>(corrTime);
   double frac = corrTime - sec;
   nanoSec = (uint32_t) (1E9 * frac);
   return (true);

--- a/include/sick_scan/softwarePLL.h
+++ b/include/sick_scan/softwarePLL.h
@@ -83,6 +83,8 @@ public:
 
   void disableCorrection();
 
+  void enableCorrection();
+
   static const int fifoSize = 7;
   size_t packets_dropped = 0;    // just for printing statusmessages when dropping packets
   size_t packets_received = 0;   // just for printing statusmessages when dropping packets

--- a/include/sick_scan/softwarePLL.h
+++ b/include/sick_scan/softwarePLL.h
@@ -31,7 +31,19 @@ public:
 
   bool pushIntoFifo(double curTimeStamp, uint32_t curtick);// update tick fifo and update clock (timestamp) fifo;
   double extraPolateRelativeTimeStamp(uint32_t tick);
+  double convertToRelativeTimeStamp(uint32_t tick);
 
+  /**
+   * \brief returns a timestamp which was corrected
+   *
+   *  Either performs a correction or just splits the ticks into seconds and nano-seconds
+   *  if the correctionDisabled is set
+   *
+   * @param sec the resulting seconds after splitting the ticks
+   * @param nanoSec the resulting nano-seconds after performing the split of the ticks
+   * @param tick the ticks used to encode the time of the measurement
+   * @return true iff the ticks have been converted to seconds and nano-seconds
+   */
   bool getCorrectedTimeStamp(uint32_t &sec, uint32_t &nanoSec, uint32_t tick);
 
   bool convSystemtimeToLidarTimestamp(uint32_t systemtime_sec, uint32_t systemtime_nanosec, uint32_t& tick);

--- a/include/sick_scan/softwarePLL.h
+++ b/include/sick_scan/softwarePLL.h
@@ -81,6 +81,8 @@ public:
 
   int findDiffInFifo(double diff, double tol);
 
+  void disableCorrection();
+
   static const int fifoSize = 7;
   size_t packets_dropped = 0;    // just for printing statusmessages when dropping packets
   size_t packets_received = 0;   // just for printing statusmessages when dropping packets
@@ -105,6 +107,7 @@ private:
   uint32_t mostRecentNanoSec;
   double mostRecentTimeStamp;
   double interpolationSlope;
+  bool correctionDisabled;
 
   bool nearSameTimeStamp(double relTimeStamp1, double relTimeStamp2, double& delta_time_abs);
 
@@ -117,6 +120,7 @@ private:
     AllowedTimeDeviation(SoftwarePLL::MaxAllowedTimeDeviation); // 1 ms
     numberValInFifo = 0;
     isInitialized = false;
+    correctionDisabled = false;
   }
 
   // verhindert, dass ein Objekt von au�erhalb von N erzeugt wird.

--- a/include/sick_scansegment_xd/config.h
+++ b/include/sick_scansegment_xd/config.h
@@ -185,6 +185,7 @@ namespace sick_scansegment_xd
         std::vector<int> laserscan_layer_filter; // Default: { 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, i.e. laserscan messages for layer 5 activated (elevation -0.07 degree, max number of scan points)
 
         rosNodePtr node; // NodePtr node; // ROS node handle (always 0 on non-ros-targets)
+        bool use_pll_correction;
 
     }; // class Config
 


### PR DESCRIPTION
This should be reviewd after the merge of the #1 .
It adds a prameter use_pll_correction to define if the pll algorithm is used to adapt the timestamp within the message header.
If set to false the timestamp of the scanner is used. This reduces jitter for new laser scan (e.g. the pico scan)